### PR TITLE
Added missing defaults for config.prefix and config.cssSuffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,11 +19,21 @@ module.exports = function (config, callback) {
 	var fsutil = require("./lib/fsutil");
 	var svgutil = require("./lib/svgutil");
 	
-	var unit = config.unit || 10;
+	// Humble defaults
+	var defaults = {
+		unit: 10,
+		prefix: "",
+		cssSuffix: "css"
+	}
+
+	// Merge defaults with user configuration
+	config = _.assign(defaults, config);
 
 	var root = path.relative(process.cwd(), config.spriteElementPath);
 	var spriteName = config.name;
+	var unit = config.unit;
 	var suffix = ".svg";
+
 	if (config.prefix && !("cssPrefix" in config)) {
 		config.cssPrefix = config.prefix;
 	}


### PR DESCRIPTION
If you use dr-svg-sprites without grunt, defaults for `config.prefix` and `config.cssSuffix` are missing.
This causes multiple `undefined` in the css file.

![error](https://f.cloud.github.com/assets/992674/2368641/45bb48f6-a7b5-11e3-9419-e878ddaaf683.png)
