### PR TITLE
Accept and handle config option cssPath

### DIFF
--- a/lib/build-css.js
+++ b/lib/build-css.js
@@ -7,7 +7,7 @@ module.exports = function (sprite, callback) {
 
 	var config = sprite.config;
 
-	
+
 	handlebars.registerHelper("url", function (filepath, relation) {
 		if (typeof relation == "string") {
 			relation = path.dirname(relation);
@@ -15,7 +15,13 @@ module.exports = function (sprite, callback) {
 		else {
 			relation = config.cssPath;
 		}
-		return path.relative(relation, filepath).replace(/\\/g, "/");
+
+        if (config.cssUrl){
+            var filename = filepath.substring(filepath.lastIndexOf('/')+1);
+            return config.cssUrl + '/' + filename;
+        } else {
+            return path.relative(relation, filepath).replace(/\\/g, "/");
+        }
 	});
 
 	handlebars.registerHelper("unit", function (value, modifier) {
@@ -47,7 +53,7 @@ module.exports = function (sprite, callback) {
 
 		var compiler = handlebars.compile(template);
 		var source = compiler(sprite);
-		
+
 		source = source.replace(/(^(\r\n)+)|((\r\n)+$)/g, "").replace(/(\r\n)+/g, "\r\n");
 
 		util.write(sprite.cssPath, source, function () {


### PR DESCRIPTION
Relative filepaths to write urls in css don’t always work. Added new
option 'cssPath' in config. If set, css url will be used in favor of
relative path
