### PR TITLE
Prevent an extra "../" in background-image url with cssPath filename option

### DIFF
--- a/lib/build-css.js
+++ b/lib/build-css.js
@@ -13,7 +13,13 @@ module.exports = function (sprite, callback) {
 			relation = path.dirname(relation);
 		}
 		else {
-			relation = config.cssPath;
+			//if the path includes filename return dirname
+			if (path.basename(config.cssPath).indexOf(".") > -1) {
+				relation = path.dirname(config.cssPath);
+			}
+			else {
+				relation = config.cssPath;
+			}
 		}
 		return path.relative(relation, filepath).replace(/\\/g, "/");
 	});


### PR DESCRIPTION
if you specify a filename in options.cssPath, the path.relative function return an extra "../" level due to the filename.
Add a test if contains "." return cssPath dirname
