### PR TITLE
Fix ID clobbering via SVGO prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ module.exports = function (config, callback) {
 
 	// generate a usable prefix from a file object
 	function prefix(file) {
-		return path.basename(file.relative, ".svg").split(path.SEP).join("-");
+		return file.relative.replace(/\.svg$/, "").split(path.SEP).join("-");
 	}
 
 };


### PR DESCRIPTION
Basically, during that first "discovery" phase, I generate a prefix by getting the relative path, stripping off the `.svg` and lastly separating by hyphens instead of slashes. (just to be clean about it) That prefix is then passed to the `cleanupIDs` plugin as the `prefix` param.

This is a _very_ simple solution, but it works for me. Depending on how exactly SVGO handles merging/normalizing config, there may be caveats here for someone wanting to further customize the `cleanupIDs` SVGO plugin, but I think that's pretty unlikely.
