### PR TITLE
Invalid CSS file if sprite path doesn't have any svg file

### DIFF
--- a/lib/build-css.js
+++ b/lib/build-css.js
@@ -39,8 +39,14 @@ module.exports = function (sprite, callback) {
 			throw err;
 		}
 
-		var compiler = handlebars.compile(template);
-		var source = compiler(sprite);
+		var source;
+
+		if (0 === sprite.items.length) {
+			source = '/* Not found any SVG file... */'
+		} else {
+			var compiler = handlebars.compile(template);
+			source = compiler(sprite);
+		}
 
 		util.write(sprite.cssPath, source, callback);
 	});

--- a/lib/build-css.js
+++ b/lib/build-css.js
@@ -41,7 +41,7 @@ module.exports = function (sprite, callback) {
 
 		var source;
 
-		if (0 === sprite.items.length) {
+		if (sprite.items.length === 0) {
 			source = '/* Not found any SVG file... */'
 		} else {
 			var compiler = handlebars.compile(template);

--- a/lib/build-png.js
+++ b/lib/build-png.js
@@ -2,6 +2,10 @@ var async = require("async");
 var svg2png = require("svg2png");
 
 module.exports = function (sprite, callback) {
+	// Items not found
+	if (0 === sprite.items.length) {
+		return ("function" === typeof callback) ? callback() : undefined;
+	}
 
 	var tasks = sprite.sizes.map(function (size) {
 		return function (callback) {

--- a/lib/build-png.js
+++ b/lib/build-png.js
@@ -3,7 +3,7 @@ var svg2png = require("svg2png");
 
 module.exports = function (sprite, callback) {
 	// Items not found
-	if (0 === sprite.items.length) {
+	if (sprite.items.length === 0) {
 		return ("function" === typeof callback) ? callback() : undefined;
 	}
 

--- a/lib/build-svg.js
+++ b/lib/build-svg.js
@@ -5,7 +5,7 @@ var svgutil = require("./svgutil");
 
 module.exports = function (sprite, callback) {
 	// Items not found
-	if (0 === sprite.items.length) {
+	if (sprite.items.length === 0) {
 		return ("function" === typeof callback) ? callback() : undefined;
 	}
 	

--- a/lib/build-svg.js
+++ b/lib/build-svg.js
@@ -4,7 +4,11 @@ var util = require("./util");
 var svgutil = require("./svgutil");
 
 module.exports = function (sprite, callback) {
-
+	// Items not found
+	if (0 === sprite.items.length) {
+		return ("function" === typeof callback) ? callback() : undefined;
+	}
+	
 	var items = sprite.items.map(function (item) {
 		return svgutil.transform(item.source, item.x, item.y);
 	});

--- a/test/prebuilt/emptyCss/emptyCss-sprite.css
+++ b/test/prebuilt/emptyCss/emptyCss-sprite.css
@@ -1,0 +1,1 @@
+/* Not found any SVG file... */

--- a/test/prebuilt/emptyCss/index.html
+++ b/test/prebuilt/emptyCss/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>emptyCss</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1"/>
+		<style>
+			* {
+				padding: 0;
+				margin: 0;
+			}
+			body {
+				padding: 20px;
+				font-family: Arial, sans-serif;
+			}
+			h2 {
+				line-height: 1;
+				margin-bottom: 20px;
+				padding-bottom: 20px;
+				border-bottom: black 1px solid;
+			}
+			h3 {
+				line-height: 1;
+				margin-bottom: 20px;
+				padding-bottom: 20px;
+				border-bottom: lightgrey 1px solid;
+			}
+			.icon-test-container + h2 {
+				margin-top: 80px;
+			}
+			.icon-test-size {
+				margin-top: 40px;
+			}
+			.icon-test-size + .icon-test-size {
+				_border-top: lightgrey 1px solid;
+				margin-top: 20px;
+				padding-top: 20px;
+			}
+			span {
+				display: inline-block;
+				margin-right: 20px;
+				vertical-align: top;
+				width: 50px;
+				height: 50px;
+			}
+			span:hover {
+				background-color: #FF8;
+			}
+			hr {
+				margin: 20px 0;
+			}
+		</style>
+		<link href="emptyCss-sprite.css" rel="stylesheet" />
+	</head>
+	<body>
+		<h2>SVG</h2>
+		<div class="icon-test-container svg ">
+				<div class="icon-test-size">
+					
+				</div>
+		</div>
+
+		<h2>PNG</h2>
+		<div class="icon-test-container ">
+				<div class="icon-test-size">
+					
+				</div>
+		</div>
+	</body>
+</html>

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,5 +1,5 @@
 module.exports = [
-	
+
 	{
 		name: "spriteElementPath-string"
 	},
@@ -133,6 +133,11 @@ module.exports = [
 			small: [13],
 			medium: [26]
 		}
+	},
+
+	{
+		name: "emptyCss",
+		spriteElementPath: "./test/source/img/noSvg/*.svg"
 	},
 
 	/*


### PR DESCRIPTION
In details I described changes [here](https://github.com/drdk/grunt-dr-svg-sprites/issues/50).

In case when plugin doesn't find svg files - plugin will generate invalid CSS. This MR will fix it.